### PR TITLE
Include UUID, polygons in aStar path; add `timingInfo` config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,11 @@ var navMesh = plugin.buildFromTileLayer(tileMap, tileLayer, {
 });
 ```
 Params:
-* `collisionIndices` an `Array` of collision indices that your tilemap uses for collisions **(required)**
-* `midPointThreshold` a `Number` value telling how narrow a navmesh triangle needs to be before it's ignored during pathing (optional; default `0`)
-* `useMidPoint` a `Boolean` value on whether to include all triangle edge mid-points in calculating triangulation (optional; default: `true`)
-* `debug` various optional debug options to Render the stages of NavMesh calculation:
+* `collisionIndices`: an `Array` of collision indices that your tilemap uses for collisions **(required)**
+* `midPointThreshold`: a `Number` value telling how narrow a navmesh triangle needs to be before it's ignored during pathing (optional; default `0`)
+* `timingInfo`: Show in the console how long it took to build the NavMesh - and search for paths (optional; default `false`)
+* `useMidPoint`: a `Boolean` value on whether to include all triangle edge mid-points in calculating triangulation (optional; default: `true`)
+* `debug`: various optional debug options to Render the stages of NavMesh calculation:
     * `hulls`: Every (recursive) 'chunk' of impassable tiles found on the tilemap
     * `navMesh`: Draw all the actual triangles generated for this navmesh
     * `navMeshNodes`: Draw all connections found between neighbouring triangles

--- a/src/demo/demoState.js
+++ b/src/demo/demoState.js
@@ -157,6 +157,7 @@ export default class DemoState extends State {
 
     this.navMesh = this.plugin.buildFromTileLayer(tileMap, tileLayer, {
       collisionIndices: COLLISION_INDICES,
+      timingInfo: true,
       midPointThreshold: 0,
       debug: {
         hulls: false,

--- a/src/lib/astar/aStarPath.js
+++ b/src/lib/astar/aStarPath.js
@@ -1,12 +1,13 @@
 import { areLinesEqual } from '../utils';
 import Funnel from './funnel';
 import Config from '../config';
+import uuid from 'uuid';
 
 export default class AStarPath {
 
   /**
    * @constructor
-   * @param {Array} polygons
+   * @param {NavMeshPolygon[]} polygons
    * @param {Object} options
    */
   constructor(polygons = [], options = {}) {
@@ -20,6 +21,7 @@ export default class AStarPath {
     this.startPolygon = startPolygon;
     this.endPolygon = endPolygon;
     this.portals = [];
+    this.uuid = uuid();
 
     this.initPortals();
     this.initFunnel();

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -1,5 +1,6 @@
 const defaultConfig = {
   collisionIndices: [],
+  timingInfo: false,
   midPointThreshold: 0,
   tileMap: null,
   tileLayer: null,

--- a/src/lib/navMesh.js
+++ b/src/lib/navMesh.js
@@ -21,35 +21,43 @@ export default class NavMesh {
    * @method generate
    */
   generate() {
-    const timerName = '[NavMeshPlugin] NavMesh generated in';
+    const timerName = '[NavMeshPlugin] 🛠 Building NavMesh. Beep Boop Boop 🤖';
     const collisionIndices = Config.get('collisionIndices');
 
     if (!collisionIndices || !collisionIndices.length) {
       console.error('[NavMeshPlugin] No collision-indices found, cannot generate NavMesh. Exiting...');
     }
 
-    console.warn('[NavMeshPlugin] 🛠 Building NavMesh. Beep Boop Boop 🤖');
-    console.time(timerName);
+    Config.get('timingInfo') && console.time(timerName);
     this.delaunay.generate();
     this.aStar = new AStar(this); // Calculate the a-star grid for the polygons.
-    console.timeEnd(timerName);
 
+    Config.get('timingInfo') && console.timeEnd(timerName);
     Debug.draw(this.delaunay);
   }
 
   /**
    * @method getPath
+   * @param {Phaser.Point} startPosition
+   * @param {Phaser.Point} endPosition
+   * @param {Number} offset
    */
   getPath(startPosition, endPosition, offset) {
+    const timerName = '[NavMeshPlugin] 🛠 Search for optimal path...';
     const { aStar } = this;
+    Config.get('timingInfo') && console.time(timerName);
+
     const aStarPath = aStar.search(startPosition, endPosition);
     if (!aStarPath) {
+      Config.get('timingInfo') && console.timeEnd(timerName);
       return false;
     }
 
-    const path = aStarPath.path;
+    const { path, polygons, uuid } = aStarPath;
     const offsetPath = offsetFunnelPath(path, offset);
-    return { path, offsetPath };
+    Config.get('timingInfo') && console.timeEnd(timerName);
+
+    return { path, polygons, offsetPath, uuid };
   }
 
   /**


### PR DESCRIPTION
- Includes a `uuid` value & the calculated `NavMeshPolygons` found during the aStar search
- Add a config value `timingInfo` to toggle the `console.time()` outputs