### PR TITLE
Merge tileLayer to 1D array, allow 'sprite' blockages on grid

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,9 @@
     <p>
         <strong>Left click</strong> to draw random colliding tile to map;
         <strong>Right click</strong> to move sprites to that point on map;
-        <strong>'P'</strong> to pause
+        <strong>'P'</strong> to pause;
+        <strong>'S'</strong> to toggle the 'sprite' dropper;
+        <strong>'K'</strong> to remove the last 'sprite' and refresh
     </p>
     <script src="demo.bundle.js"></script>
 </body>

--- a/src/demo/demoState.js
+++ b/src/demo/demoState.js
@@ -22,7 +22,7 @@ export default class DemoState extends State {
   preload() {
     const { game } = this;
     this.plugin = game.plugins.add(NavMeshPlugin);
-    // this.timing = game.plugins.add(AdvancedTiming, { mode: 'graph' });
+    this.timing = game.plugins.add(AdvancedTiming, { mode: 'graph' });
 
     // Load the demo assets
     game.load.image('ground_1x1', 'assets/tilemaps/tiles/ground_1x1.png');
@@ -53,17 +53,16 @@ export default class DemoState extends State {
     game.canvas.oncontextmenu = this.onRightClick;
 
     this.cursors = game.input.keyboard.createCursorKeys();
+    this.isSpriteStamp = false;
+    this.spriteUUIDs = [];
     game.input.keyboard.addKey(Keyboard.P).onDown.add(() => game.paused = !game.paused, this);
     game.input.keyboard.addKey(Keyboard.SPACEBAR).onDown.add(() => game.paused = !game.paused, this);
+    game.input.keyboard.addKey(Keyboard.S).onDown.add(() => this.isSpriteStamp = !this.isSpriteStamp);
+    game.input.keyboard.addKey(Keyboard.K).onDown.add(() => this.removeSprite());
 
     this.spriteGroup = new Phaser.Group(game);
 
-    // new DemoSprite(game, 100, 50, this.spriteGroup, this.tileLayer);
-    // new DemoSprite(game, 600, 60, this.spriteGroup, this.tileLayer);
     new DemoSprite(game, 200, 500, this.spriteGroup, this.tileLayer);
-    // new DemoSprite(game, world.randomX, world.randomY, this.spriteGroup, this.tileLayer);
-    // new DemoSprite(game, world.randomX, world.randomY, this.spriteGroup, this.tileLayer);
-    // new DemoSprite(game, world.randomX, world.randomY, this.spriteGroup, this.tileLayer);
   }
 
   /**
@@ -100,7 +99,7 @@ export default class DemoState extends State {
       x = startAtX;
       xLength = startAtX + 20;
       for (x; x < xLength; x++) {
-        if (x !== startAtX && y !== startAtY && x !== xLength - 4 && y !== yLength - 1) {
+        if (x !== startAtX && y !== startAtY && x !== xLength - 1 && y !== yLength - 1) {
           continue;
         }
 
@@ -243,15 +242,20 @@ export default class DemoState extends State {
   /**
    * @method updateMarker
    */
-  updateMarker() {
-    const { game, tileLayer, tileMap } = this;
-    const { activePointer, mousePointer } = game.input;
+  updateMarker({ leftButton, worldX, worldY }, originalEvent, c) {
+    const { tileLayer, tileMap } = this;
+
+    if (this.isSpriteStamp) {
+      return this.updateSprite(leftButton, worldX, worldY);
+    }
+    this.stamp && this.stamp.clear();
+
     const tile = Math.floor(PhaserMath.random(0, COLLISION_INDICES.length));
 
-    const x = tileLayer.getTileX(activePointer.worldX) * TILE_SIZE;
-    const y = tileLayer.getTileY(activePointer.worldY) * TILE_SIZE;
+    const x = tileLayer.getTileX(worldX) * TILE_SIZE;
+    const y = tileLayer.getTileY(worldY) * TILE_SIZE;
 
-    if (mousePointer.leftButton.isDown) {
+    if (leftButton.isDown) {
       tileMap.putTile(tile, tileLayer.getTileX(x), tileLayer.getTileY(y), tileLayer);
       this.updateNavMesh(1000);
     }
@@ -266,5 +270,46 @@ export default class DemoState extends State {
       clearTimeout(timeout);
     }
     timeout = setTimeout(() => this.buildNavMesh(), delay);
+  }
+
+  /**
+   * @method updateSprite
+   * @description Track the mouse movement and 'stamp' a test cluster onto the map
+   */
+  updateSprite(leftButton, x, y) {
+    const { tileWidth, tileHeight } = this.tileMap;
+    const stampWidth = 3;
+    const stampHeight = 2;
+
+    if (!this.stamp) {
+      this.stamp = this.game.add.graphics(0, 0);
+    } else {
+      this.stamp.clear();
+    }
+
+    this.stamp.beginFill(0x0000ff, 0.8);
+    const tileX = Math.floor(x / 32);
+    const tileY = Math.floor(y / 32);
+    this.stamp.drawRect(tileX * tileWidth, tileY * tileHeight, stampWidth * tileWidth, stampHeight * tileHeight);
+    this.stamp.endFill();
+
+    if (!leftButton.isDown) {
+      return;
+    }
+
+    const { uuid } = this.plugin.addSprite(tileX, tileY, stampWidth, stampHeight);
+    this.spriteUUIDs.push(uuid);
+  }
+
+  /**
+   * @method removeSprite
+   * @description Pop and remove the last sprite
+   */
+  removeSprite() {
+    if (!this.spriteUUIDs.length) {
+      return;
+    }
+
+    this.plugin.removeSprite(this.spriteUUIDs.pop());
   }
 }

--- a/src/demo/demoState.js
+++ b/src/demo/demoState.js
@@ -297,8 +297,10 @@ export default class DemoState extends State {
       return;
     }
 
-    const { uuid } = this.plugin.addSprite(tileX, tileY, stampWidth, stampHeight);
-    this.spriteUUIDs.push(uuid);
+    const sprite = this.plugin.addSprite(tileX, tileY, stampWidth, stampHeight);
+    if (sprite) {
+      this.spriteUUIDs.push(sprite.uuid);
+    }
   }
 
   /**

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -32,6 +32,19 @@ class Config {
     return MapGrid.getAt(x, y);
   }
 
+  /**
+   * @method toggleTileBlockedAtXY
+   * @param {Number} x
+   * @param {Number} y
+   * @param {Boolean} toggle
+   */
+  toggleTileBlockedAtXY(x, y, toggle) {
+    MapGrid.toggleBlocked(x, y, toggle);
+  }
+
+  /**
+   * @method gridDimensions
+   */
   get gridDimensions() {
     const { width, height } = MapGrid;
     return { width, height };

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -22,6 +22,10 @@ class Config {
     return this._c[key];
   }
 
+  get mapGrid() {
+    return MapGrid;
+  }
+
   /**
    * @method getTileAt
    * @param {Number} x
@@ -30,16 +34,6 @@ class Config {
    */
   getTileAt(x, y) {
     return MapGrid.getAt(x, y);
-  }
-
-  /**
-   * @method toggleTileBlockedAtXY
-   * @param {Number} x
-   * @param {Number} y
-   * @param {Boolean} toggle
-   */
-  toggleTileBlockedAtXY(x, y, toggle) {
-    MapGrid.toggleBlocked(x, y, toggle);
   }
 
   /**

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -1,3 +1,5 @@
+import MapGrid from './map/grid';
+
 const defaultConfig = {
   collisionIndices: [],
   timingInfo: false,
@@ -21,6 +23,21 @@ class Config {
   }
 
   /**
+   * @method getTileAt
+   * @param {Number} x
+   * @param {Number} y
+   * @return {MapTile}
+   */
+  getTileAt(x, y) {
+    return MapGrid.getAt(x, y);
+  }
+
+  get gridDimensions() {
+    const { width, height } = MapGrid;
+    return { width, height };
+  }
+
+  /**
    * @method mapDimensions
    * @return {Object}
    */
@@ -35,6 +52,7 @@ class Config {
    */
   set(config = defaultConfig) {
     this._c = { ...defaultConfig, ...config };
+    MapGrid.copyFrom(config.tileLayer.layer.data);
   }
 }
 

--- a/src/lib/delaunay/cluster.js
+++ b/src/lib/delaunay/cluster.js
@@ -93,9 +93,9 @@ export default class Cluster extends MarchingSquares {
     }
 
     if (invert) {
-      return collisionIndices.indexOf(tile.index) > -1;
+      return collisionIndices.indexOf(tile.index) > -1 || tile.blocked;
     } else {
-      return collisionIndices.indexOf(tile.index) === -1;
+      return collisionIndices.indexOf(tile.index) === -1 && !tile.blocked;
     }
   }
 

--- a/src/lib/delaunay/cluster.js
+++ b/src/lib/delaunay/cluster.js
@@ -1,12 +1,13 @@
 import { optimiseEdges } from '../utils';
 import MarchingSquares from './marchingSquares';
+import Config from '../config';
 
 /**
  * @class Cluster
  */
 export default class Cluster extends MarchingSquares {
-  constructor(contours, edges, grid, collisionIndices, invert = false) {
-    super(grid, collisionIndices);
+  constructor(contours, edges, invert = false) {
+    super();
 
     this.polygon = new Phaser.Polygon(contours);
     this.edges = edges;
@@ -23,11 +24,11 @@ export default class Cluster extends MarchingSquares {
    * @description
    */
   generate() {
-    const { collisionIndices, grid, invert } = this;
+    const { invert } = this;
 
     this.children = [];
     super.generate((contours, edges) => {
-      this.children.push(new Cluster(contours, edges, grid, collisionIndices, !invert));
+      this.children.push(new Cluster(contours, edges, !invert));
     });
   }
 
@@ -72,8 +73,7 @@ export default class Cluster extends MarchingSquares {
       return false;
     }
 
-    const row = this.grid[tileY];
-    return row && row[tileX];
+    return Config.getTileAt(tileX, tileY);
   }
 
   /**
@@ -84,7 +84,8 @@ export default class Cluster extends MarchingSquares {
    * @param {Number} y
    */
   isValidTile(x, y) {
-    const { collisionIndices, invert, polygon } = this;
+    const collisionIndices = Config.get('collisionIndices');
+    const { invert, polygon } = this;
     const tile = this.get(x, y);
 
     if (!polygon.contains(x, y) || this.isChild(x, y) || !tile) {

--- a/src/lib/delaunay/hulls.js
+++ b/src/lib/delaunay/hulls.js
@@ -61,7 +61,7 @@ export default class Hulls extends MarchingSquares {
     }
 
     const tile = this.get(x, y);
-    return tile && (collisionIndices.indexOf(tile.index) > -1 );
+    return tile && (collisionIndices.indexOf(tile.index) > -1 || tile.blocked);
   }
 
   /**

--- a/src/lib/delaunay/hulls.js
+++ b/src/lib/delaunay/hulls.js
@@ -10,9 +10,7 @@ export default class Hulls extends MarchingSquares {
    * @constructor
    */
   constructor() {
-    const { data } = Config.get('tileLayer').layer;
-    super(data, Config.get('collisionIndices'));
-
+    super();
     this.generate();
   }
 
@@ -22,11 +20,9 @@ export default class Hulls extends MarchingSquares {
    *              the interior of that Cluster is checked for any 'reverse'
    */
   generate() {
-    const { grid, collisionIndices } = this;
-
     this.clusters = [];
     super.generate((contours, edges) => {
-      this.clusters.push(new Cluster(contours, edges, grid, collisionIndices));
+      this.clusters.push(new Cluster(contours, edges));
     });
   }
 
@@ -34,9 +30,7 @@ export default class Hulls extends MarchingSquares {
    * @method getStartingPoint
    */
   getStartingPoint() {
-    const { grid } = this;
-    const height = grid.length;
-    const width = grid[0].length;
+    const { width, height } = Config.gridDimensions;
     let y = 0;
     let x;
     const offsetPoint = new Phaser.Point();
@@ -60,14 +54,14 @@ export default class Hulls extends MarchingSquares {
    *              part of a discovered outline of a chunk, so it's safe to ignore
    */
   isValidTile(x, y) {
-    const { collisionIndices } = this;
+    const collisionIndices = Config.get('collisionIndices');
 
     if (this.isPartOfCluster(x, y)) {
       return false;
     }
 
     const tile = this.get(x, y);
-    return tile && collisionIndices.indexOf(tile.index) > -1;
+    return tile && (collisionIndices.indexOf(tile.index) > -1 );
   }
 
   /**

--- a/src/lib/delaunay/marchingSquares.js
+++ b/src/lib/delaunay/marchingSquares.js
@@ -1,3 +1,5 @@
+import Config from '../config';
+
 const WHILE_CEILING = 500;
 const DIRECTIONS = {
   NONE: 0,
@@ -8,11 +10,6 @@ const DIRECTIONS = {
 };
 
 export default class MarchingSquares {
-  constructor(grid, collisionIndices) {
-    this.collisionIndices = collisionIndices;
-    this.grid = grid;
-  }
-
   /**
    * @method generate
    * @param {Function} onClusterFound
@@ -75,8 +72,7 @@ export default class MarchingSquares {
    * @method get
    */
   get(x, y) {
-    const row = this.grid[y];
-    return row && row[x];
+    return Config.getTileAt(x, y);
   }
 
   /**

--- a/src/lib/map/grid.js
+++ b/src/lib/map/grid.js
@@ -36,7 +36,6 @@ class MapGrid {
    * @param {Array} tileLayer
    */
   copyFrom(tileLayer = []) {
-    console.warn('copyFrom', tileLayer);
     if (!tileLayer.length) {
       return;
     }

--- a/src/lib/map/grid.js
+++ b/src/lib/map/grid.js
@@ -1,4 +1,5 @@
 import MapTile from './tile';
+import MapSprite from './sprite';
 
 /**
  * @class MapGrid
@@ -10,6 +11,7 @@ class MapGrid {
    */
   constructor() {
     this.data = [];
+    this.sprites = [];
     this.width = null;
     this.height = null;
   }
@@ -52,6 +54,56 @@ class MapGrid {
         this.data.push(new MapTile(tileLayer[y][x]));
       }
     }
+  }
+
+  /**
+   * @method addSprite
+   * @description Add a 'sprite' that acts as a blocker within the map-grid
+   */
+  addSprite(x, y, width, height) {
+    const tiles = [];
+    const yLength = y + height;
+    const xLength = x + width;
+    let yy = y;
+    let xx;
+    let tile;
+
+    for (yy; yy < yLength; yy++) {
+      xx = x;
+      for (xx; xx < xLength; xx++) {
+        tile = this.getAt(xx, yy);
+        if (tile) {
+          tile.blocked = true;
+          tiles.push(tile);
+        }
+      }
+    }
+
+    const sprite = new MapSprite(x, y, width, height, tiles);
+    this.sprites.push(sprite);
+
+    return sprite;
+  }
+
+  /**
+   * @method removeSprite
+   * @description Remove sprite, toggle tiles back to false (but only those not overlapping with other sprites)
+   * @param {String} uuid
+   */
+  removeSprite(uuid) {
+    const { tiles } = this.sprites.find(sprite => sprite.uuid === uuid);
+    let overlapping;
+
+    // First, remove the sprite matching the provided UUID
+    this.sprites = this.sprites.filter(sprite => sprite.uuid !== uuid);
+
+    // Now, iterate through the removed Sprite's tiles and toggle to FALSE only those NOT also in other Sprites
+    tiles.forEach(tile => {
+      overlapping = this.sprites.find(sprite => sprite.tiles.find(t => t.x === tile.x && t.y === tile.y));
+      if (!overlapping) {
+        tile.blocked = false;
+      }
+    });
   }
 
   /**

--- a/src/lib/map/grid.js
+++ b/src/lib/map/grid.js
@@ -17,6 +17,17 @@ class MapGrid {
   }
 
   /**
+   * @method findSprite
+   * @param {Number} x
+   * @param {Number} y
+   * @param {Number} width
+   * @param {Number} height
+   */
+  findSprite(x, y, width, height) {
+    return this.sprites.find(s => s.x === x && s.y === y && s.width === width && s.height === height);
+  }
+
+  /**
    * @method get
    */
   get() {
@@ -67,6 +78,11 @@ class MapGrid {
     let yy = y;
     let xx;
     let tile;
+
+    // If we already added a sprite with these exact dimensions, ignore
+    if (this.findSprite(x, y, width, height)) {
+      return false;
+    }
 
     for (yy; yy < yLength; yy++) {
       xx = x;

--- a/src/lib/map/grid.js
+++ b/src/lib/map/grid.js
@@ -1,0 +1,74 @@
+import MapTile from './tile';
+
+/**
+ * @class MapGrid
+ * @description Contains a flattened, 1D Array copy of the Phaser.TilemapLayer imported from copyFrom()
+ */
+class MapGrid {
+  /**
+   * @constructor
+   */
+  constructor() {
+    this.data = [];
+    this.width = null;
+    this.height = null;
+  }
+
+  /**
+   * @method get
+   */
+  get() {
+    return this.data;
+  }
+
+  /**
+   * @method getAt
+   * @param {Number} x
+   * @param {Number} y
+   */
+  getAt(x, y) {
+    const i = y * this.width + x;
+    return this.get()[i];
+  }
+
+  /**
+   * @method copyFrom
+   * @param {Array} tileLayer
+   */
+  copyFrom(tileLayer = []) {
+    console.warn('copyFrom', tileLayer);
+    if (!tileLayer.length) {
+      return;
+    }
+
+    this.data = [];
+    this.width = tileLayer[0].length;
+    this.height = tileLayer.length;
+    let y = 0;
+    let x;
+
+    for (y; y < this.height; y++) {
+      x = 0;
+      for (x; x < this.width; x++) {
+        this.data.push(new MapTile(tileLayer[y][x]));
+      }
+    }
+  }
+
+  /**
+   * @method toggleBlocked
+   * @description Set the tile to ${blocked} if param present, otherwise toggle the value
+   * @param {Number} x
+   * @param {Number} y
+   * @param {Boolean} blocked
+   */
+  toggleBlocked(x, y, blocked) {
+    const tile = this.getAt(x, y);
+    if (tile) {
+      tile.blocked = blocked !== undefined ? blocked : !tile.blocked;
+    }
+  }
+
+}
+
+export default new MapGrid();

--- a/src/lib/map/sprite.js
+++ b/src/lib/map/sprite.js
@@ -1,0 +1,12 @@
+import uuid from 'uuid';
+
+export default class MapSprite {
+  constructor(x, y, width, height, tiles = []) {
+    this.x = x;
+    this.y = y;
+    this.width = width;
+    this.height = height;
+    this.uuid = uuid();
+    this.tiles = tiles;
+  }
+}

--- a/src/lib/map/tile.js
+++ b/src/lib/map/tile.js
@@ -1,0 +1,15 @@
+/**
+ * @class MapTile
+ */
+export default class MapTile {
+  /**
+   * @constructor
+   * @param {Object} tile
+   */
+  constructor({ x, y, index }) {
+    this.x = x;
+    this.y = y;
+    this.index = index;
+    this.blocked = false;
+  }
+}

--- a/src/lib/navMesh.js
+++ b/src/lib/navMesh.js
@@ -31,6 +31,7 @@ export default class NavMesh {
     Config.get('timingInfo') && console.time(timerName);
     this.delaunay.generate();
     this.aStar = new AStar(this); // Calculate the a-star grid for the polygons.
+    this.updatedAt = Date.now();
 
     Config.get('timingInfo') && console.timeEnd(timerName);
     Debug.draw(this.delaunay);
@@ -55,9 +56,10 @@ export default class NavMesh {
 
     const { path, polygons, uuid } = aStarPath;
     const offsetPath = offsetFunnelPath(path, offset);
+    const createdAt = Date.now();
     Config.get('timingInfo') && console.timeEnd(timerName);
 
-    return { path, polygons, offsetPath, uuid };
+    return { createdAt, path, polygons, offsetPath, uuid };
   }
 
   /**

--- a/src/lib/navMeshPlugin.js
+++ b/src/lib/navMeshPlugin.js
@@ -49,7 +49,7 @@ export default class NavMeshPlugin extends Phaser.Plugin {
     }
 
     const sprite = Config.mapGrid.addSprite(x, y, width, height);
-    if (refresh) {
+    if (sprite && refresh) {
       this.navMesh.generate();
     }
 

--- a/src/lib/navMeshPlugin.js
+++ b/src/lib/navMeshPlugin.js
@@ -18,7 +18,6 @@ export default class NavMeshPlugin extends Phaser.Plugin {
    * @param {Object} options
    */
   buildFromTileLayer(tileMap, tileLayer, options = {}) {
-    const opts = Object.assign({}, defaultOptions, options);
     if (!tileMap || !tileLayer) {
       return err();
     }
@@ -27,7 +26,7 @@ export default class NavMeshPlugin extends Phaser.Plugin {
     Debug.set(this.game, tileLayer, options.debug);
 
     if (this.navMesh) {
-      this.navMesh.generate(opts);
+      this.navMesh.generate();
     } else {
       this.navMesh = new NavMesh(this.game);
     }
@@ -36,19 +35,43 @@ export default class NavMeshPlugin extends Phaser.Plugin {
   }
 
   /**
-   * @method toggleBlockedAtXY
+   * @method addSprite
    * @param {Number} x
    * @param {Number} y
+   * @param {Number} width
+   * @param {Number} height
+   * @param {Boolean} refresh
    */
-  toggleBlockedAtXY(x, y) {
+  addSprite(x, y, width, height, refresh = true) {
     const tileLayer = Config.get('tileLayer');
     if (!tileLayer) {
       return err();
     }
 
-    Config.toggleTileBlockedAtXY(x, y);
+    const sprite = Config.mapGrid.addSprite(x, y, width, height);
+    if (refresh) {
+      this.navMesh.generate();
+    }
+
+    return sprite;
   }
 
+  /**
+   * @method removeSprite
+   * @param {String} uuid
+   * @param {Boolean} refresh
+   */
+  removeSprite(uuid, refresh = true) {
+    const tileLayer = Config.get('tileLayer');
+    if (!tileLayer) {
+      return err();
+    }
+
+    Config.mapGrid.removeSprite(uuid);
+    if (refresh) {
+      this.navMesh.generate();
+    }
+  }
 }
 
 window.NavMeshPlugin = NavMeshPlugin;

--- a/src/lib/navMeshPlugin.js
+++ b/src/lib/navMeshPlugin.js
@@ -2,6 +2,10 @@ import NavMesh, { defaultOptions } from './navMesh';
 import Config from './config';
 import Debug from './debug';
 
+function err() {
+  return console.error('[NavMeshPlugin] no TileMap / TileLayer found');
+}
+
 export default class NavMeshPlugin extends Phaser.Plugin {
   constructor(game, manager) {
     super(game, manager);
@@ -16,7 +20,7 @@ export default class NavMeshPlugin extends Phaser.Plugin {
   buildFromTileLayer(tileMap, tileLayer, options = {}) {
     const opts = Object.assign({}, defaultOptions, options);
     if (!tileMap || !tileLayer) {
-      return console.error('[NavMeshPlugin] no TileMap / TileLayer found');
+      return err();
     }
 
     Config.set({ tileMap, tileLayer, ...options });
@@ -30,6 +34,21 @@ export default class NavMeshPlugin extends Phaser.Plugin {
 
     return this.navMesh;
   }
+
+  /**
+   * @method toggleBlockedAtXY
+   * @param {Number} x
+   * @param {Number} y
+   */
+  toggleBlockedAtXY(x, y) {
+    const tileLayer = Config.get('tileLayer');
+    if (!tileLayer) {
+      return err();
+    }
+
+    Config.toggleTileBlockedAtXY(x, y);
+  }
+
 }
 
 window.NavMeshPlugin = NavMeshPlugin;


### PR DESCRIPTION
- On `buildFromTileLayer`, flatten the tileLayer data to a 1D array for easier iteration; also, instance each grid item as custom `MapTile` class to allow for custom 'blocked' property
- Allow the add / remove of 'sprites' to the navMesh, temp overrides that block movement across the tileLayer; these manipulate the aforementioned `blocked` property.

Closes #10 