### PR TITLE
Extend options, include all hull edges

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Params:
 * `midPointThreshold`: a `Number` value telling how narrow a navmesh triangle needs to be before it's ignored during pathing (optional; default `0`)
 * `timingInfo`: Show in the console how long it took to build the NavMesh - and search for paths (optional; default `false`)
 * `useMidPoint`: a `Boolean` value on whether to include all triangle edge mid-points in calculating triangulation (optional; default: `true`)
+* `offsetHullsBy`: a `Number` value to offset (expand) each hull cluster by. Useful to use a small value to prevent excessively parallel edges (optional; default: `0.1`)
 * `debug`: various optional debug options to Render the stages of NavMesh calculation:
     * `hulls`: Every (recursive) 'chunk' of impassable tiles found on the tilemap
     * `navMesh`: Draw all the actual triangles generated for this navmesh

--- a/src/demo/demoState.js
+++ b/src/demo/demoState.js
@@ -99,7 +99,7 @@ export default class DemoState extends State {
       x = startAtX;
       xLength = startAtX + 20;
       for (x; x < xLength; x++) {
-        if (x !== startAtX && y !== startAtY && x !== xLength - 1 && y !== yLength - 1) {
+        if (x !== startAtX && y !== startAtY && x !== xLength - 4 && y !== yLength - 1) {
           continue;
         }
 

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -2,10 +2,11 @@ import MapGrid from './map/grid';
 
 const defaultConfig = {
   collisionIndices: [],
-  timingInfo: false,
   midPointThreshold: 0,
+  offsetHullsBy: 0.1,
   tileMap: null,
   tileLayer: null,
+  timingInfo: false,
   useMidPoint: false
 };
 

--- a/src/lib/debug.js
+++ b/src/lib/debug.js
@@ -60,40 +60,23 @@ class Debug {
   drawDelaunay(delaunay) {
     const { gfx, settings } = this;
     const { polygons } = delaunay;
-    const { clusters } = delaunay.hulls;
+    const { allEdges } = delaunay.hulls;
     gfx.clear();
 
-    function drawCluster(cluster) {
-      gfx.beginFill(DEBUG_COLOUR_RED, 0.6);
-      gfx.drawPolygon(cluster.polygon.points.map(this.getWorldXY, this));
-      gfx.endFill();
-      const [startEdge, ...otherEdges] = cluster.edges;
-      const startEdgeStart = this.getWorldXY(startEdge.start);
-      const startEdgeEnd = this.getWorldXY(startEdge.end);
-
+    function drawEdge(edge) {
+      const start = (edge.start);
+      const end = (edge.end);
       gfx.lineStyle(2, DEBUG_COLOUR_YELLOW);
-      gfx.moveTo(startEdgeStart.x, startEdgeStart.y);
-      gfx.lineTo(startEdgeEnd.x, startEdgeEnd.y);
-
-      otherEdges.forEach(edge => {
-        const start = this.getWorldXY(edge.start);
-        const end = this.getWorldXY(edge.end);
-
-        gfx.moveTo(start.x, start.y);
-        gfx.lineTo(end.x, end.y);
-      });
+      gfx.moveTo(start.x, start.y);
+      gfx.lineTo(end.x, end.y);
       gfx.lineStyle(0);
-
-      if (cluster.children.length) {
-        cluster.children.forEach(drawCluster, this);
-      }
     }
 
     /**
      * @description Render the hulls found using the Marching Squares algorithm
      */
     if (settings.hulls) {
-      clusters.forEach(drawCluster, this);
+      allEdges.forEach(drawEdge, this);
     }
 
     /**
@@ -114,7 +97,7 @@ class Debug {
 
       gfx.lineStyle(lineWidth, 0x00b2ff, 0.5);
       polygons.forEach((poly) => {
-        poly.neighbors.forEach((neighbour) => {
+        poly.neighbors.forEach(neighbour => {
           gfx.moveTo(poly.centroid.x, poly.centroid.y);
           gfx.lineTo(neighbour.centroid.x, neighbour.centroid.y);
         });

--- a/src/lib/delaunay/delaunayGenerator.js
+++ b/src/lib/delaunay/delaunayGenerator.js
@@ -59,7 +59,11 @@ export default class DelaunayGenerator {
   generate() {
     const options = { exterior: false };
 
-    this.hulls = new Hulls();
+    if (this.hulls) {
+      this.hulls.generate();
+    } else {
+      this.hulls = new Hulls();
+    }
 
     this.parseHullClusters();
 

--- a/src/lib/delaunay/hulls.js
+++ b/src/lib/delaunay/hulls.js
@@ -24,6 +24,34 @@ export default class Hulls extends MarchingSquares {
     super.generate((contours, edges) => {
       this.clusters.push(new Cluster(contours, edges));
     });
+
+    this.extractAllEdges();
+  }
+
+  /**
+   * @method extractAllEdges
+   * @description Extract all edges from all clusters
+   */
+  extractAllEdges() {
+    const { width, height, tileWidth, tileHeight } = Config.mapDimensions;
+    const w = width * tileWidth;
+    const h = height * tileHeight;
+    this.allEdges = [
+      new Phaser.Line(0, 0, w, 0),
+      new Phaser.Line(w, 0, w, h),
+      new Phaser.Line(w, h, 0, h),
+      new Phaser.Line(0, h, 0, 0)
+    ];
+
+    const parseCluster = ({ children, edges }) => {
+      this.allEdges = this.allEdges.concat(edges.map(({ start, end }) => ({
+        start: start.clone().multiply(tileWidth, tileHeight),
+        end: end.clone().multiply(tileWidth, tileHeight)
+      })));
+      children.forEach(parseCluster);
+    };
+
+    this.clusters.forEach(parseCluster);
   }
 
   /**

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -2,7 +2,6 @@ import EdgePoint from './delaunay/edgePoint';
 import Config from './config';
 
 const THREE_SIXTY_DEGREES = Math.PI * 2;
-const OFFSET_BY = 0.1;
 
 export function areLinesEqual(line1, line2) {
   const line1Start = line1.start;
@@ -184,7 +183,7 @@ export function optimiseEdges(edges) {
  */
 export function offsetPolygon(points = [], invert, clusters = []) {
   const { width, height } = Config.mapDimensions;
-  const offsetBy = OFFSET_BY * (invert ? -1 : 1);
+  const offsetBy = Config.get('offsetHullsBy') * (invert ? -1 : 1);
   const pointsLength = points.length;
   const offsetPoint = new Phaser.Point();
   let i = 0;
@@ -265,11 +264,3 @@ export function offsetEdges(edges = [], invert = false, clusters = []) {
 
   return edges;
 }
-
-const defaultOffsetOptions = {
-  offset: OFFSET_BY,
-  invert: false,
-  width: -1,
-  height: -1
-};
-


### PR DESCRIPTION
* Add new option, `offsetHullsBy` which allows configuration of the offset applied to all clusters during Delaunay generation
* Extract all the edges of each `Cluster`, for any use later or by other code